### PR TITLE
GH-24: Remove tostring() to avoid a syntax error

### DIFF
--- a/samples/AppInsights/KQL/Long Running SQL Queries.kql
+++ b/samples/AppInsights/KQL/Long Running SQL Queries.kql
@@ -38,7 +38,7 @@ traces
 traces
 | where timestamp > ago(60d) // adjust as needed
 | where operation_Name == 'Long Running Operation (SQL Query)' // do note that in a later version of the schema, this field will not be used (a new field in custom dimensions will be used)
-| extend alObjectId = tostring( customDimensions.['AL Object Id'] )
+| extend alObjectId = customDimensions.['AL Object Id']
 | where alObjectId > 0 // filter out internal server calls
 | extend aadID = customDimensions.['AadTenantId']
        , executionTime = customDimensions.['Execution time (ms)']


### PR DESCRIPTION
### Description

#24 Remove `tostring()` from `alObjectId` in Long Running SQL Queries.kql

### Motivation and Context

To avoid a syntax error.
