### PR TITLE
Add TSG for technical validation results of AppSource submissions

### DIFF
--- a/samples/AppInsights/TroubleShootingGuides/D365BC Troubleshooting Guides (TSG)/_data/toc.yml
+++ b/samples/AppInsights/TroubleShootingGuides/D365BC Troubleshooting Guides (TSG)/_data/toc.yml
@@ -3,6 +3,8 @@
   sections:
   - title: "README (which TSGs are good for what)"
     url: /README
+  - title: "AppSource submission results"
+    url: /AppSource-Submission-TSG
   - title: "Database issues"
     url: /Data-related-TSG
   - title: "Deprecated feature usage"

--- a/samples/AppInsights/TroubleShootingGuides/D365BC Troubleshooting Guides (TSG)/content/AppSource-Submission-TSG.ipynb
+++ b/samples/AppInsights/TroubleShootingGuides/D365BC Troubleshooting Guides (TSG)/content/AppSource-Submission-TSG.ipynb
@@ -1,0 +1,621 @@
+{
+    "metadata": {
+        "kernelspec": {
+            "name": "python3",
+            "display_name": "Python 3",
+            "language": "python"
+        },
+        "language_info": {
+            "name": "python",
+            "version": "3.9.1",
+            "mimetype": "text/x-python",
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "pygments_lexer": "ipython3",
+            "nbconvert_exporter": "python",
+            "file_extension": ".py"
+        }
+    },
+    "nbformat_minor": 2,
+    "nbformat": 4,
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "source": [
+                "# Dynamics 365 Business Central Trouble Shooting Guide (TSG) - AppSource Submission Results (SaaS)\n",
+                "\n",
+                "This notebook contains Kusto queries that can help analyzing the results of the technical validation of your AppSource submission.\n",
+                "\n",
+                "NB! The signal used in this notebook is only available starting from October 2021 when the fully automated technical validation was released."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "1f608a1d-2436-4b48-80d4-5c4d2f8ca7d0"
+            }
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "## 1\\. Get setup: Load up Python libraries and connect to Application Insights\n",
+                "\n",
+                "First you need to set the notebook Kernel to Python3, load the KQLmagic module (did you install it?) and connect to your Application Insights resource (get appid and appkey from the API access page in the Application Insights portal)"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "f103fae9-cf6d-40f7-9062-11ce50691046"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "# load the KQLmagic module\r\n",
+                "%reload_ext Kqlmagic"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "a253fa8e-6ac2-4722-a00a-1c52aedab4ed",
+                "tags": []
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "# Connect to the Application Insights API\r\n",
+                "%kql appinsights://appid='<add app id from the Application Insights portal>';appkey='<add API key from the Application Insights portal>'"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "76c5fa02-b403-4c57-8c7d-3150e9d4270a",
+                "tags": []
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "## 2\\. Define filters\n",
+                "\n",
+                "This workbook is designed for analyzing a single submission. Please provide a value for the validationRequestId. This ID is provided in Partner Center UI if your submission has failed at the automated validation step."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "9ef1220c-d9cc-4552-9297-1428efcafb32"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "# Validation Request Id\r\n",
+                "validationRequestId = \"<add validation request ID>\"\r\n",
+                "\r\n",
+                "# Date filters for the analysis\r\n",
+                "# use YYYY-MM-DD format for the dates (ISO 8601)\r\n",
+                "startDate = \"2021-10-01\"\r\n",
+                "endDate = \"2021-12-31\"\r\n",
+                "\r\n",
+                "print(\"Using these parameters for the analysis:\")\r\n",
+                "print(\"----------------------------------------\")\r\n",
+                "print(\"validationRequestId \" + validationRequestId)\r\n",
+                "print(\"startDate           \" + startDate)\r\n",
+                "print(\"endDate             \" + endDate)"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "0a0785f7-a85e-4ccf-9020-732e1d4c058a",
+                "tags": []
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "# Analyze the technical validation results\n",
+                "\n",
+                "Now you can run Kusto queries to look for your validation results.\n",
+                "\n",
+                "This notebooks allows you to find:\n",
+                "\n",
+                "- which extensions have been validated \n",
+                "- which country/regions have been validated\n",
+                "- which releases of Business Central have been validated\n",
+                "- which diagnostics have been reported during the validation\n",
+                "- which baseline extensions have been used during the validation\n",
+                "- which dependency extensions have been used during the validation\n",
+                "\n",
+                "Either click **Run All** above to run all sections, or scroll down to the type of analysis you want to do and manually run queries.  \n",
+                "\n",
+                "Documentation of the AppSource Submission Signals: [https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/administration/telemetry-appsource-submission-validation-trace](https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/administration/telemetry-appsource-submission-validation-trace)"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "5f9b698d-8a7e-4757-b27d-02f219d6c589"
+            }
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "## Technical Validation Process\n",
+                "\n",
+                "As part of the technical validation, all extensions in your submission are validated for all the country/regions and releases targeted.\n",
+                "\n",
+                "For each combinaison of target country/region and release, your extensions are compiled with the AL compiler and the AppSourceCop analyzer against the dependencies available for the country/region. Additional checks are also performed by the validation service itself (for instance, verifying that the runtime version in the manifest of the extensions is compatible with the releases targeted by your submission).\n",
+                "\n",
+                "Documentation of the Technical Validation Checklist: [https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-checklist-submission](https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-checklist-submission)\n",
+                "\n",
+                "Documentation of the AppSourceCop code analyzer: [https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/appsourcecop](https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/appsourcecop)"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "60af9a03-52da-43cd-b2d1-4d90613d1501"
+            }
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "## Extensions validated for your submission\n",
+                "\n",
+                "The list of extensions validated for your submission is specified when creating the offer in Partner Center."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "3109e186-1b8a-41c4-8eef-caa85586f6c6"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "%%kql\r\n",
+                "let _validationRequestId = validationRequestId;\r\n",
+                "let _startDate = startDate;\r\n",
+                "let _endDate = endDate;\r\n",
+                "traces\r\n",
+                "| where timestamp between (todatetime(_startDate) .. todatetime(_endDate))   \r\n",
+                "    and customDimensions.validationRequestId == _validationRequestId\r\n",
+                "    and customDimensions.eventId == 'LC0028'\r\n",
+                "| project extensions = customDimensions.extensions"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "5023a509-c9e8-41fb-a694-1de489d45523",
+                "tags": [
+                    "hide_input"
+                ]
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "If the list of extensions does not match your expectations, verify the files you have uploaded on the tab 'Configuration' of your offer in Partner Center."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "3682e4fe-fbac-4c0d-9757-dce9b10d23f3"
+            }
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "## Countries/regions validated for your submission\n",
+                "\n",
+                "The list of countries/regions validated for your submission is specified when creating the offer in Partner Center."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "2f9c2d0d-df3c-482b-af58-48416a517117"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "%%kql\r\n",
+                "let _validationRequestId = validationRequestId;\r\n",
+                "let _startDate = startDate;\r\n",
+                "let _endDate = endDate;\r\n",
+                "traces\r\n",
+                "| where timestamp between (todatetime(_startDate) .. todatetime(_endDate))   \r\n",
+                "    and customDimensions.validationRequestId == _validationRequestId\r\n",
+                "    and customDimensions.eventId == 'LC0028'\r\n",
+                "| project countryRegions = customDimensions.countryRegions"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "ad2d8e8f-9b53-4406-90d0-eecc908ab7af",
+                "tags": [
+                    "hide_input"
+                ]
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "If your extension is already available for some countries, it won't be validated for these countries.  \n",
+                "  \n",
+                "The query below shows you for which country regions each extension was validated."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "72fbe59a-f9a1-4bca-bbd9-0111a5e44579"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "%%kql\r\n",
+                "let _validationRequestId = validationRequestId;\r\n",
+                "let _startDate = startDate;\r\n",
+                "let _endDate = endDate;\r\n",
+                "traces\r\n",
+                "| where timestamp between (todatetime(_startDate) .. todatetime(_endDate))   \r\n",
+                "    and customDimensions.validationRequestId == _validationRequestId\r\n",
+                "    and customDimensions.eventId == 'LC0032'\r\n",
+                "| project countryRegion = customDimensions.countryRegion\r\n",
+                ", extensionId = tostring(customDimensions.extensionId)\r\n",
+                ", extensionName = tostring(customDimensions.extensionName)\r\n",
+                ", extensionPublisher = tostring(customDimensions.extensionPublisher)\r\n",
+                ", extensionVersion = tostring(customDimensions.extensionVersion)\r\n",
+                "| summarize countryRegions = make_set(countryRegion) by extensionId, extensionName, extensionPublisher, extensionVersion\r\n",
+                "| project extensionId, extensionName, extensionPublisher, extensionVersion, countryRegions\r\n",
+                "| order by extensionName asc"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "a9e923e9-1d05-4acf-a230-4c5142bc3582",
+                "tags": [
+                    "hide_input"
+                ]
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "If the list of country/regions does not match your expectations, verify the country/regions that you have selected under 'Markets' in the tab 'Availability' of your offer in Partner Center."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "b0d41ea9-2ee8-4735-b733-cd9de06046ed"
+            }
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "## Releases validated for your submission\n",
+                "\n",
+                "The list of releases targeted by your submission is computed based on the manifests (app.json) of the extensions in your submission.\n",
+                "\n",
+                "Read more about the computation of the releases targeted by your submission here: [hhttps://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-checklist-submission](https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-checklist-submission#versions)"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "2f7e604a-0d02-484e-9bcb-a6aa148d5f0b"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "%%kql\r\n",
+                "let _validationRequestId = validationRequestId;\r\n",
+                "let _startDate = startDate;\r\n",
+                "let _endDate = endDate;\r\n",
+                "traces\r\n",
+                "| where timestamp between (todatetime(_startDate) .. todatetime(_endDate))   \r\n",
+                "    and customDimensions.validationRequestId == _validationRequestId\r\n",
+                "    and customDimensions.eventId == 'LC0028'\r\n",
+                "| project versions = customDimensions.versions"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "9ec9b678-7d66-4758-9101-4e9e5025dfcf",
+                "tags": [
+                    "hide_input"
+                ]
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "If the list of releases does not match your expectations, verify the manifest (app.json) of the extensions that you have uploaded in the 'Configuration' tab of your offer in Partner Center."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "a59274da-380a-4e2f-8da4-fe3d939fd9ca"
+            }
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "## Result of the submission\n",
+                "\n",
+                "If you see a signal with the eventId **LC0029**, then your submission **passed** the technical validation.\n",
+                "\n",
+                "If you see a signal with the eventId **LC0035**, then your submission **failed** the technical validation."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "810235a1-c202-47a2-b9dc-4d4d1ffd123c"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "%%kql\r\n",
+                "let _validationRequestId = validationRequestId;\r\n",
+                "let _startDate = startDate;\r\n",
+                "let _endDate = endDate;\r\n",
+                "traces\r\n",
+                "| where timestamp between (todatetime(_startDate) .. todatetime(_endDate))   \r\n",
+                "    and customDimensions.validationRequestId == _validationRequestId\r\n",
+                "    and customDimensions.eventId in (\"LC0029\", \"LC0035\")\r\n",
+                "| project validationResult = case(customDimensions.eventId == \"LC0029\", \"The technical validation of your offer succeeded!\",\r\n",
+                "                                  customDimensions.eventId == \"LC0035\", \"The technical validation of your offer failed!\",\r\n",
+                "                                  \"Unknown\")"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "6426410c-182a-486c-8466-228cb9ce3228",
+                "tags": [
+                    "hide_input"
+                ]
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "A task is considered as failed when at least one diagnostic with severity Error has been reported. You can analyze the reported diagnostics in the next section.\n",
+                "\n",
+                "This query shows you which extensions in your submission have **passed** the technical validation and for which country/region and release."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "e2f65078-e3df-4121-80cc-2574f18014b3"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "%%kql\r\n",
+                "let _validationRequestId = validationRequestId;\r\n",
+                "let _startDate = startDate;\r\n",
+                "let _endDate = endDate;\r\n",
+                "traces\r\n",
+                "| where timestamp between (todatetime(_startDate) .. todatetime(_endDate))   \r\n",
+                "    and customDimensions.validationRequestId == _validationRequestId\r\n",
+                "    and customDimensions.eventId == 'LC0033'\r\n",
+                "| project timestamp\r\n",
+                ", version = tostring(customDimensions.version)\r\n",
+                ", countryRegion = tostring(customDimensions.countryRegion)\r\n",
+                ", extensionId = tostring(customDimensions.extensionId)\r\n",
+                ", extensionName = tostring(customDimensions.extensionName)\r\n",
+                ", extensionPublisher = tostring(customDimensions.extensionPublisher)\r\n",
+                ", extensionVersion = tostring(customDimensions.extensionVersion)\r\n",
+                "| distinct extensionId, extensionName, extensionPublisher, extensionVersion, countryRegion, version\r\n",
+                "| order by extensionName, countryRegion, version asc"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "c4ce60dd-35e7-4154-93d9-f83671ca84c5",
+                "tags": [
+                    "hide_input"
+                ]
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "This query shows you which extensions in your submission have **failed** the technical validation and for which country/region and release."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "44961815-d974-4440-b9e2-70e61fddc0a0"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "%%kql\r\n",
+                "let _validationRequestId = validationRequestId;\r\n",
+                "let _startDate = startDate;\r\n",
+                "let _endDate = endDate;\r\n",
+                "traces\r\n",
+                "| where timestamp between (todatetime(_startDate) .. todatetime(_endDate))   \r\n",
+                "    and customDimensions.validationRequestId == _validationRequestId\r\n",
+                "    and customDimensions.eventId == 'LC0037'\r\n",
+                "| project timestamp\r\n",
+                ", version = tostring(customDimensions.version)\r\n",
+                ", countryRegion = tostring(customDimensions.countryRegion)\r\n",
+                ", extensionId = tostring(customDimensions.extensionId)\r\n",
+                ", extensionName = tostring(customDimensions.extensionName)\r\n",
+                ", extensionPublisher = tostring(customDimensions.extensionPublisher)\r\n",
+                ", extensionVersion = tostring(customDimensions.extensionVersion)\r\n",
+                "| distinct extensionId, extensionName, extensionPublisher, extensionVersion, countryRegion, version\r\n",
+                "| order by extensionName, countryRegion, version asc"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "eafe3040-6ed8-4989-8a6f-374630042eaa",
+                "tags": [
+                    "hide_input"
+                ]
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "## Diagnostics reported for failed tasks\n",
+                "\n",
+                "There are three types of diagnostics reported during the technical validation:\n",
+                "\n",
+                "| Diagnostic Source | Diagnostic Prefix | Example |\n",
+                "| --- | --- | --- |\n",
+                "| AL Compiler | AL | AL0001 |\n",
+                "| AppSourceCop | AS | AS0001 |\n",
+                "| Validation Service | AVS | AVS0001 |"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "7ed10cbf-6380-4591-ad66-8dc6b886ba48"
+            }
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "You can specify additional filters if you want to look for a specific task."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "289a88d9-8b79-4d8d-9aa2-f263dc037463"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "# Optional parameters, if you want to investigate the results for a specific task\r\n",
+                "extensionId   = \"\"      # The app ID of the extension that failed validation\r\n",
+                "countryRegion = \"\"      # The country/region for which the extension failed validation\r\n",
+                "version       = \"\"      # add version of BC for which the extension failed validation\r\n",
+                "\r\n",
+                "print(\"Using additional optional parameters for the analysis:\")\r\n",
+                "print(\"----------------------------------------\")\r\n",
+                "print(\"extensionId         \" + extensionId)\r\n",
+                "print(\"countryRegion       \" + countryRegion)\r\n",
+                "print(\"version             \" + version)"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "44693d4b-029a-4b57-b81c-8667491e358b",
+                "tags": []
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "The query below returns all the diagnostics reported for tasks that failed the technical validation and are matching your optional filers if any."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "c05a34e2-3fe3-4e4e-827c-4392220404c3"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "%%kql\r\n",
+                "let _validationRequestId = validationRequestId;\r\n",
+                "let _startDate = startDate;\r\n",
+                "let _endDate = endDate;\r\n",
+                "let _extensionId = extensionId;\r\n",
+                "let _countryRegion = countryRegion;\r\n",
+                "let _version = version;\r\n",
+                "traces\r\n",
+                "| where timestamp between (todatetime(_startDate) .. todatetime(_endDate))   \r\n",
+                "    and customDimensions.validationRequestId == _validationRequestId\r\n",
+                "    and customDimensions.eventId == 'LC0034'\r\n",
+                "    and (customDimensions.extensionId == _extensionId or _extensionId == \"\")\r\n",
+                "    and (customDimensions.countryRegion == _countryRegion or _countryRegion == \"\")\r\n",
+                "    and (customDimensions.version == _version or _version == \"\")\r\n",
+                "| project timestamp\r\n",
+                ", version = tostring(customDimensions.version)\r\n",
+                ", countryRegion = tostring(customDimensions.countryRegion)\r\n",
+                ", extensionName = tostring(customDimensions.extensionName)\r\n",
+                ", diagnosticCode = tostring(customDimensions.diagnosticCode)\r\n",
+                ", diagnosticSource = case(customDimensions.diagnosticCode startswith \"AL\", \"AL Compiler\",\r\n",
+                "                          customDimensions.diagnosticCode startswith \"AS\", \"AppSourceCop\",\r\n",
+                "                          customDimensions.diagnosticCode startswith \"AVS\", \"Validation Service\",\r\n",
+                "                          \"Unknown\")\r\n",
+                ", diagnosticDocumentation = case(customDimensions.diagnosticCode startswith \"AS\", strcat(\"https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/analyzers/appsourcecop-\", customDimensions.diagnosticCode),\r\n",
+                "                                 \"N/A\")\r\n",
+                ", diagnosticSeverity = tostring(customDimensions.diagnosticSeverity)\r\n",
+                ", diagnosticMessage = tostring(customDimensions.diagnosticMessage)\r\n",
+                ", diagnosticSourcePath = tostring(customDimensions.diagnosticSourcePath)\r\n",
+                ", diagnosticSourceLocation = tostring(customDimensions.diagnosticSourceLocation)\r\n",
+                "| project extensionName, countryRegion, version, diagnosticCode, diagnosticSeverity, diagnosticMessage, diagnosticSourcePath, diagnosticSourceLocation, diagnosticSource, diagnosticDocumentation\r\n",
+                "| order by extensionName, countryRegion, version asc"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "f8e7955e-2b86-410b-98ad-f4979d85e879",
+                "tags": [
+                    "hide_input"
+                ]
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "If an extension failed the validation because the **AppSourceCop reported a breaking change**, you can **investigate which baseline versions have been used** during the validation in the dedicated section below.\n",
+                "\n",
+                "If an extension failed the validation because the **AL Compiler reported a compilation error**, you can **investigate which dependencies have been used** during the validation in the dedicated section below."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "dfb206cc-2840-4603-bb22-e80e55e46cef"
+            }
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "## Baseline versions used during breaking change validation\n",
+                "\n",
+                "During the validation, the baseline versions used during breaking change validation are computed by taking the highest available version of the extensions in your submission for each targeted country/region."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "27f3ce3d-c8da-4ece-a03d-61dcfa7ecf00"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "%%kql\r\n",
+                "let _validationRequestId = validationRequestId;\r\n",
+                "let _startDate = startDate;\r\n",
+                "let _endDate = endDate;\r\n",
+                "traces\r\n",
+                "| where timestamp between (todatetime(_startDate) .. todatetime(_endDate))   \r\n",
+                "    and customDimensions.validationRequestId == _validationRequestId\r\n",
+                "    and customDimensions.eventId == 'LC0030'\r\n",
+                "| project countryRegion = tostring(customDimensions.countryRegion)\r\n",
+                ", version = tostring(customDimensions.version)\r\n",
+                ", extensions = customDimensions.extensions\r\n",
+                ", baselineExtensions = customDimensions.baselineExtensions\r\n",
+                "| order by countryRegion, version asc"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "b0d9a7fd-4592-4983-80ac-b6df6f2d21a3",
+                "tags": [
+                    "hide_input"
+                ]
+            },
+            "outputs": [],
+            "execution_count": null
+        },
+        {
+            "cell_type": "markdown",
+            "source": [
+                "## Dependency versions used during the validation\n",
+                "\n",
+                "During the validation, the dependency versions are computed by taking the highest available version of the depenencies for each targeted country/region and release."
+            ],
+            "metadata": {
+                "azdata_cell_guid": "732e68d4-0cff-4d60-8e32-e91ecba5e058"
+            }
+        },
+        {
+            "cell_type": "code",
+            "source": [
+                "%%kql\r\n",
+                "let _validationRequestId = validationRequestId;\r\n",
+                "let _startDate = startDate;\r\n",
+                "let _endDate = endDate;\r\n",
+                "traces\r\n",
+                "| where timestamp between (todatetime(_startDate) .. todatetime(_endDate))   \r\n",
+                "    and customDimensions.validationRequestId == _validationRequestId\r\n",
+                "    and customDimensions.eventId == 'LC0030'\r\n",
+                "| project countryRegion = tostring(customDimensions.countryRegion)\r\n",
+                ", version = tostring(customDimensions.version)\r\n",
+                ", extensions = customDimensions.extensions\r\n",
+                ", allExtensions = customDimensions.allExtensions\r\n",
+                "| order by countryRegion, version asc"
+            ],
+            "metadata": {
+                "azdata_cell_guid": "2a2300b7-4e83-4a4f-b227-6b2e4561a6bb",
+                "tags": [
+                    "hide_input"
+                ]
+            },
+            "outputs": [],
+            "execution_count": null
+        }
+    ]
+}

--- a/samples/AppInsights/TroubleShootingGuides/D365BC Troubleshooting Guides (TSG)/content/README.ipynb
+++ b/samples/AppInsights/TroubleShootingGuides/D365BC Troubleshooting Guides (TSG)/content/README.ipynb
@@ -20,8 +20,11 @@
                 "Welcome to the D365BC troubleshooting guides. Use them to troublehoot D365BC environments or apps (require that telemetry have been setup)\n",
                 "**Quick tip!** If you need to run multiple notebooks against the same configuration, then take a copy of the _notebook.ini_ file, and copy it to _c:\\\\tmp_. Then you can edit filter variables in the file and all notebooks will pick them up when running the code cell for filters."
             ],
-            "metadata": {
-                "azdata_cell_guid": "2346ce11-7c8c-49a2-b100-4ff45ed5048f"
+            "metadata": {\n",
+                "\n",
+                "\n",
+                "Install instructions for Azure Data Studio with KQL magic: https://github.com/microsoft/BCTech/tree/master/samples/AppInsights/TroubleShootingGuides
+                "azdata_cell_guid": "b53a5b97-9e27-4515-924c-3612c8fc15ec"
             }
         },
         {

--- a/samples/AppInsights/TroubleShootingGuides/D365BC Troubleshooting Guides (TSG)/content/README.ipynb
+++ b/samples/AppInsights/TroubleShootingGuides/D365BC Troubleshooting Guides (TSG)/content/README.ipynb
@@ -20,11 +20,8 @@
                 "Welcome to the D365BC troubleshooting guides. Use them to troublehoot D365BC environments or apps (require that telemetry have been setup)\n",
                 "**Quick tip!** If you need to run multiple notebooks against the same configuration, then take a copy of the _notebook.ini_ file, and copy it to _c:\\\\tmp_. Then you can edit filter variables in the file and all notebooks will pick them up when running the code cell for filters."
             ],
-            "metadata": {\n",
-                "\n",
-                "\n",
-                "Install instructions for Azure Data Studio with KQL magic: https://github.com/microsoft/BCTech/tree/master/samples/AppInsights/TroubleShootingGuides
-                "azdata_cell_guid": "b53a5b97-9e27-4515-924c-3612c8fc15ec"
+            "metadata": {
+                "azdata_cell_guid": "2346ce11-7c8c-49a2-b100-4ff45ed5048f"
             }
         },
         {
@@ -36,6 +33,7 @@
                 "|  |  |\n",
                 "| --- | --- |\n",
                 "| **TSG** | **Useful for** |\n",
+                "| [AppSource submission results TSG](./AppSource-Submission-TSG.ipynb)| Use this TSG to analyze the technical validation results for your AppSource submissions. |\n",
                 "| [Database issues TSG](./Data-related-TSG.ipynb) <br><br>[notebook.ini](./notebook.ini) | Use this TSG to analyze data-related issues for a single environment, such as <ul><li>Long running queries</li><li>Database locks</li><li>Reports that runs many sql statements</li></ul> |\n",
                 "| [Extension issues TSG](./Extensions-TSG.ipynb) <br><br>[notebook.ini](./notebook.ini)| Use this TSG to analyze issues with the extension lifecycle (compile, synchronize, publish, install, update, un-install, un-publish). You can set filters on AAD tenant id, environment name, and extension id to troubleshoot<ul><li>all environments in a AAD tenant id</li><li>a single environment</li><li>a single extensions</li></ul> |\n",
                 "| [Login issues TSG](./Login-issues-TSG.ipynb) <br><br>[notebook.ini](./notebook.ini) | Use this TSG for cases related to login issues in a single environment, such as <ul><li>if one or more users cannot login (check failure reasons in authorization checks before/after onCompanyOpen trigger</li><li>to troubleshoot if a login issue is related to firewall/network issues at the customer site (check if web service requests get in but client requests are not present)</li><li>to check if logins are successful again after an incident </li></ul>|\n",

--- a/samples/AppInsights/TroubleShootingGuides/README.md
+++ b/samples/AppInsights/TroubleShootingGuides/README.md
@@ -10,6 +10,7 @@ This repository contains Jupyter Notebook TSGs for
 * Investigating login issues (authentication and authorization flows)
 * Investigating if environments are using deprecated web service protocols
 * Investigating lifecycle issues with extensions (compile, synchronize, publish, install, update, un-install, un-publish)
+* Investigating results for the technical validation of AppSource submissions
 
 | TSG | Description |
 | ----------- | ----------- |
@@ -20,6 +21,8 @@ This repository contains Jupyter Notebook TSGs for
 | Performance-partner-code-TSG.ipynb | Use this TSG to analyze performance problems in partner code. The TSG filters telemetry on object ids outside the ranges used for the base app and localizations (the code written by Microsoft) | 
 | Data-related-TSG.ipynb | Use this TSG to analyze data-related issues: Long running queries, database locks, reports that runs many sql statements | 
 | Extensions-TSG.ipynb | Use this TSG to analyze issues with the extension lifecycle (compile, synchronize, publish, install, update, un-install, un-publish). You can set filters on AAD tenant id, environment name, and extension id to troubleshoot all environments in a AAD tenant id, a single environment, single extensions, or any other combination of the three |
+| AppSource-Submission-TSG.ipynb | Use this TSG to analyze the results of the technical validation of AppSource submissions. You can see whether your submission passed the technical validation, which errors were reported, which countries and releases were validated, but also which baselines were used for breaking change validation |
+
 
 # What is Azure Data Studio?
 Azure Data Studio is a cross-platform database tool for data professionals using the Microsoft family of on-premises and cloud data platforms on Windows, MacOS, and Linux. Azure Data Studio offers a modern editor experience with IntelliSense, code snippets, source control integration, and an integrated terminal. It's engineered with the data platform user in mind, with built-in charting of query result sets and customizable dashboards. 


### PR DESCRIPTION
Add TSG to analyze the technical validation results of AppSource submissions. 

This includes getting the list of:
- extensions/countries/releases validated,
- extensions that passed the validation and for which country/release
- extensions that failed the validation and for which country/release
- error diagnostics reported during the technical validation
- extensions used as dependencies for each country/release
- extensions used as baseline for each country/release