### PR TITLE
hide "already synchronized" sync failures

### DIFF
--- a/samples/AppInsights/TroubleShootingGuides/D365BC Troubleshooting Guides (TSG)/content/Extensions-TSG.ipynb
+++ b/samples/AppInsights/TroubleShootingGuides/D365BC Troubleshooting Guides (TSG)/content/Extensions-TSG.ipynb
@@ -599,6 +599,7 @@
                 "    and (_environmentName == '' or customDimensions.environmentName == _environmentName )\n",
                 "    and (_extensionId == '' or customDimensions.extensionId == _extensionId)\n",
                 "    and customDimensions.eventId == 'LC0013'\n",
+                "    and customDimensions.failureReason !endswith 'already synchronized.'\n",
                 "| extend aadTenantId=tostring( customDimensions.aadTenantId)\n",
                 "       , environmentName=tostring( customDimensions.environmentName )\n",
                 "       , extensionId=tostring( customDimensions.extensionId )\n",


### PR DESCRIPTION
Hides the "Cannot synchronize the extension *** with app ID *** because it is already synchronized." Events since its not a real issue.