### PR TITLE
Blogs section added to the main readme file.

### DIFF
--- a/samples/AppInsights/README.md
+++ b/samples/AppInsights/README.md
@@ -11,7 +11,12 @@ This repo contains instructions for how you can obtain the telemetry and resourc
 
 Please visit the [FAQ page](FAQ.md) for any questions on how to get started, pricing, privacy, and more.
 
-Want some easy to digest introductions to Business Central telemetry? Watch a few short videos to get started: [Business Central Telemetry Videos](VIDEOS.md).
+Want some easy to digest introductions to Business Central telemetry?
+
+Watch a few short videos and blogs to get started: 
+
+- [Business Central Telemetry Videos](VIDEOS.md)
+- [Business Central Telemetry Blogs](BLOGS.md)
 
 # Disclaimer
 Microsoft Corporation (“Microsoft”) grants you a nonexclusive, perpetual, royalty-free right to use and modify the software code provided by us for the purposes of illustration  ("Sample Code") and to reproduce and distribute the object code form of the Sample Code, provided that you agree: (i) to not use our name, logo, or trademarks to market your software product in which the Sample Code is embedded; (ii) to include a valid copyright notice on your software product in which the Sample Code is embedded; and (iii) to indemnify, hold harmless, and defend us and our suppliers from and against any claims or lawsuits, whether in an action of contract, tort or otherwise, including attorneys’ fees, that arise or result from the use or distribution of the Sample Code or the use or other dealings in the Sample Code. Unless applicable law gives you more rights, Microsoft reserves all other rights not expressly granted herein, whether by implication, estoppel or otherwise. 


### PR DESCRIPTION
The main readme has a reference to the Videos section but it would be nice to include the Blogs as well.