### PR TITLE
Correct errors when a SL module is not used

### DIFF
--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_AP.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_AP.vb
@@ -58,6 +58,10 @@ Module Analyze_AP
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
 
+            If sResult = "NO" Then
+                Exit Sub
+            End If
+
 
             RecID = RecID + 1
             sDescr = "Number of unreleased batches:"
@@ -68,7 +72,7 @@ Module Analyze_AP
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
 
-            ' Loop through each of the companyies
+            ' Loop through each of the companies
             If (retValInt1 > 0 And MultiCpnyAppDB = True) Then
                 For Each cpny As CpnyDatabase In CpnyDBList
                     RecID = RecID + 1
@@ -1162,7 +1166,7 @@ Module Analyze_AP
             Call oEventLog.LogMessage(0, "")
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered" + ex.Message)
+            Call MessageBox.Show("Error Encountered" + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - AP")
 
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Accounts Payable data"
 

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_AR.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_AR.vb
@@ -34,17 +34,16 @@ Module Analyze_AR
         Try
             Form1.AnalysisStatusLbl.Text = "Analyzing Accounts Receivable"
 
-            ' Call TranBeg(True)Form1.
+
             '===== Accounts Receivable ======
 
             '=== Module Usage ===
             Form1.AnalysisStatusLbl.Text = "Analyzing Accounts Receivable Module Usage"
-
+            sAnalysisType = "Module Usage"
             Call oEventLog.LogMessage(0, "ACCOUNTS RECEIVABLE")
+            Call oEventLog.LogMessage(0, "")
 
             Call oEventLog.LogMessage(0, "Analyzing Accounts Receivable Module Usage")
-
-            sAnalysisType = "Module Usage"
 
             RecID = RecID + 1
             sDescr = "Is the module being used?"
@@ -61,6 +60,10 @@ Module Analyze_AR
             sqlStringValues = SParm(sAnalysisType) + "," + SParm(sDescr) + "," + SParm(CurrDateStr) + "," + SParm(sModule) + "," + CStr(RecID) + "," + SParm(sResult)
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
+
+            If sResult = "NO" Then
+                Exit Sub
+            End If
 
             RecID = RecID + 1
             sDescr = "Number of unreleased batches:"
@@ -1174,6 +1177,7 @@ Module Analyze_AR
 
 
         Catch ex As Exception
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - AR")
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Accounts Receivable data"
             OkToContinue = False
         End Try

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_BI.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_BI.vb
@@ -55,6 +55,10 @@ Module Analyze_BI
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
 
+            If sResult = "NO" Then
+                Exit Sub
+            End If
+
             RecID = RecID + 1
             sDescr = "Invoice Entry Rate Table:"
 
@@ -825,15 +829,11 @@ Module Analyze_BI
             Call oEventLog.LogMessage(0, "")
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message)
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - BI")
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Flexible Billings data"
             OkToContinue = False
 
         End Try
-
-
-
-
 
     End Sub
 

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_BM.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_BM.vb
@@ -19,10 +19,8 @@ Module Analyze_BM
         Dim sResult As String = String.Empty
         Dim retValInt1 As Integer
         Dim retValDbl1 As Double
-        ''Dim retValDbl2 As Double
         Dim retValStr1 As String = String.Empty
         Dim calcValDbl1 As Double
-        ''Dim sqlQuery As String = String.Empty
 
         Dim sqlStmt As String = String.Empty
         Dim sqlReader As SqlDataReader = Nothing
@@ -39,8 +37,6 @@ Module Analyze_BM
             Call oEventLog.LogMessage(0, "")
 
             Call oEventLog.LogMessage(0, "Analyzing Bill of Materials Module Usage")
-
-
 
             sAnalysisType = "Module Usage"
 
@@ -59,6 +55,10 @@ Module Analyze_BM
             sqlStringValues = SParm(sAnalysisType) + "," + SParm(sDescr) + "," + SParm(CurrDateStr) + "," + SParm(sModule) + "," + CStr(RecID) + "," + SParm(sResult)
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
+
+            If sResult = "NO" Then
+                Exit Sub
+            End If
 
             RecID = RecID + 1
             sDescr = "Number of unreleased batches:"
@@ -812,7 +812,7 @@ Module Analyze_BM
             Call oEventLog.LogMessage(0, "")
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message)
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - BM")
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Bill of Material data"
             OkToContinue = False
 

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_CA.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_CA.vb
@@ -4,7 +4,7 @@ Imports System.Data.SqlClient
 
 Module Analyze_CA
     '================================================================================
-    ' This module contains code to analyze tables used with the Currency Manager Module
+    ' This module contains code to analyze tables used with the Cash Manager Module
     '
     '================================================================================
 
@@ -51,6 +51,10 @@ Module Analyze_CA
             sqlStringValues = SParm(sAnalysisType) + "," + SParm(sDescr) + "," + SParm(CurrDateStr) + "," + SParm(sModule) + "," + CStr(RecID) + "," + SParm(sResult)
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
+
+            If sResult = "NO" Then
+                Exit Sub
+            End If
 
             RecID = RecID + 1
             sDescr = "Number of unreleased batches:"
@@ -485,7 +489,7 @@ Module Analyze_CA
 
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message)
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - CA")
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Cash Manager data"
             OkToContinue = False
         End Try

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_CM.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_CM.vb
@@ -50,6 +50,10 @@ Module Analyze_CM
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
 
+            If sResult = "NO" Then
+                Exit Sub
+            End If
+
             RecID = RecID + 1
             sDescr = "Base Currency ID application database (" + DBName.Trim + "):"
             sqlStmt = "SELECT BaseCuryID, Central_Cash_Cntl, COAOrder, CpnyId, LedgerID, MCActive, Mult_Cpny_Db, NbrPer, PerNbr, PerRetHist, PerRetModTran, PerRetTran, RetEarnAcct, ValidateAcctSub, YtdNetIncAcct FROM GLSetup"
@@ -308,7 +312,7 @@ Module Analyze_CM
             Call oEventLog.LogMessage(0, "")
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message)
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - CM")
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Currency Manager data"
             OkToContinue = False
 

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_GL.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_GL.vb
@@ -60,6 +60,10 @@ Module Analyze_GL
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
 
+            If sResult = "NO" Then
+                Exit Sub
+            End If
+
             RecID = RecID + 1
             sDescr = "Number of unreleased batches:"
             sqlStmt = "SELECT COUNT(Rlsed) FROM Batch WHERE Module = 'GL' AND Rlsed = 0"
@@ -1176,7 +1180,7 @@ Module Analyze_GL
             '***********************************************************************************'            
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message)
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - GL")
             ' Call TranEnd()
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing General Ledger data"
             OkToContinue = False

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_IN.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_IN.vb
@@ -54,6 +54,10 @@ Module Analyze_IN
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
 
+            If sResult = "NO" Then
+                Exit Sub
+            End If
+
             RecID = RecID + 1
             sDescr = "Number of unreleased batches:"
             sqlStmt = "SELECT COUNT(Rlsed) FROM Batch WHERE Module = 'IN' AND Rlsed = 0"
@@ -1234,7 +1238,7 @@ Module Analyze_IN
             Call oEventLog.LogMessage(0, "")
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message)
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - IN")
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Inventory data"
             OkToContinue = False
 

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_MC.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_MC.vb
@@ -57,6 +57,10 @@ Module Analyze_MC
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
 
+            If sResult = "NO" Then
+                Exit Sub
+            End If
+
             RecID = RecID + 1
             sDescr = "Is Multi-company processing enabled in Multi-Company Setup?"
             sqlStmt = "SELECT COUNT(*) FROM MCSetup WHERE MCActivated = 1"
@@ -841,12 +845,11 @@ Module Analyze_MC
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
 
-
+            Call oEventLog.LogMessage(0, "")
             Call oEventLog.LogMessage(0, "")
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message)
-            '  Call TranEnd()
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - MC")
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Multi-Company data"
             OkToContinue = False
 

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_OM.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_OM.vb
@@ -53,6 +53,10 @@ Module Analyze_OM
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
 
+            If sResult = "NO" Then
+                Exit Sub
+            End If
+
             RecID = RecID + 1
             sDescr = "Are Salespeople being used?"
             sqlStmt = "SELECT COUNT(*) FROM SOShipHeader WHERE Status = 'C' AND Cancelled = 0 AND RTRIM(SlsperID) <> ''"
@@ -1084,7 +1088,7 @@ Module Analyze_OM
 
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message)
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - OM")
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Order Management data"
             OkToContinue = False
 

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_PA.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_PA.vb
@@ -53,6 +53,10 @@ Module Analyze_PA
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
 
+            If sResult = "NO" Then
+                Exit Sub
+            End If
+
             RecID = RecID + 1
             sDescr = "Financial modules Integrated:"
             sqlStmt = "SELECT Control_Data FROM PJCONTRL WHERE control_type = 'PA' AND control_code = 'INTERFACE-LIST'"
@@ -948,7 +952,7 @@ Module Analyze_PA
 
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message)
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - PA")
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Project Controller data"
             OkToContinue = False
 

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_PO.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_PO.vb
@@ -57,6 +57,10 @@ Module Analyze_PO
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
 
+            If sResult = "NO" Then
+                Exit Sub
+            End If
+
             RecID = RecID + 1
             sDescr = "Number of unreleased batches:"
             sqlStmt = "SELECT COUNT(Rlsed) FROM Batch WHERE Module = 'PO' AND Rlsed = 0"
@@ -872,7 +876,7 @@ Module Analyze_PO
             Call oEventLog.LogMessage(0, "")
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message)
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - PO")
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Purchasing data"
             OkToContinue = False
 

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_RQ.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_RQ.vb
@@ -55,6 +55,10 @@ Module Analyze_RQ
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
 
+            If sResult = "NO" Then
+                Exit Sub
+            End If
+
             RecID = RecID + 1
             sDescr = "Are request for bids allowed?"
             sqlStmt = "SELECT ZZEnableBid FROM RQSetup"
@@ -1147,7 +1151,7 @@ Module Analyze_RQ
             Call oEventLog.LogMessage(0, "")
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message, "Error Encountered")
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - RQ")
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Requisitions data"
             OkToContinue = False
 

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_SD.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_SD.vb
@@ -55,6 +55,10 @@ Module Analyze_SD
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
 
+            If sResult = "NO" Then
+                Exit Sub
+            End If
+
             RecID = RecID + 1
             sDescr = "Date of oldest Service Call:"
             sqlStmt = "SELECT MIN(Crtd_DateTime) FROM smServCall"
@@ -796,7 +800,7 @@ Module Analyze_SD
             Call oEventLog.LogMessage(0, "")
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message, "Error Encountered")
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - SD")
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Service Dispatch data"
             OkToContinue = False
 

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_SI.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_SI.vb
@@ -239,7 +239,7 @@ Module Analyze_SI
             Call oEventLog.LogMessage(0, "")
             Call oEventLog.LogMessage(0, "")
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message)
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - SI")
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Shared Information data"
             OkToContinue = False
 

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_SN.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_SN.vb
@@ -50,6 +50,10 @@ Module Analyze_SN
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
 
+            If sResult = "NO" Then
+                Exit Sub
+            End If
+
             RecID = RecID + 1
             sDescr = "Date of oldest Contract start date:"
             sqlStmt = "SELECT MIN(StartDate) FROM smContract WHERE Status IN ('A', 'P', 'E')"
@@ -657,7 +661,7 @@ Module Analyze_SN
             Call oEventLog.LogMessage(0, "")
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message)
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - SN")
 
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Service Contracts data"
             OkToContinue = False

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_SY.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_SY.vb
@@ -438,7 +438,8 @@ Module Analyze_SY
             Call oEventLog.LogMessage(0, "")
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message)
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - SY")
+            Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Administration data"
             OkToContinue = False
 
         End Try

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_TM.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Analyze_TM.vb
@@ -57,6 +57,10 @@ Module Analyze_TM
             sqlStringExec = sqlStringStart + sqlStringValues + sqlStringEnd
             Call AddStatusInfo(sqlStringExec, sDescr, sResult)
 
+            If sResult = "NO" Then
+                Exit Sub
+            End If
+
             RecID = RecID + 1
             sDescr = "First Day of Week in Timecard Entry:"
             Call InitPJContrlValues(bPJContrlInfo)
@@ -1388,7 +1392,7 @@ Module Analyze_TM
             Call oEventLog.LogMessage(0, "")
 
         Catch ex As Exception
-            Call MessageBox.Show("Error Encountered " + ex.Message)
+            Call MessageBox.Show("Error Encountered " + ex.Message + vbNewLine + ex.StackTrace, "Error Encountered - TM")
             Form1.AnalysisStatusLbl.Text = "Error encountered while analyzing Time and Expense for Projects data"
             OkToContinue = False
 

--- a/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Form1.vb
+++ b/samples/DynamicsSLMigrationTools/Analysis and Repair Tool/Analysis Tool/Form1.vb
@@ -130,159 +130,163 @@ Friend Class Form1
             'Analyze Administration Information
             AnalysisStatusLbl.Text = "Analyzing Administration Information"
             Call Analyze_SY.Analyze_SY()
-            AnalysisStatusLbl.Text = "Finished analyzing Administration Information"
-
             If OkToContinue = True Then
-                'Analyze MC - Multi-Company
-                Call Analyze_MC.Analyze_MC()
+                AnalysisStatusLbl.Text = "Finished analyzing Administration Information"
+            Else
+                AnalysisStatusLbl.Text = "Error encountered analyzing Administration Information"
+                Exit Sub
+            End If
+
+            'Analyze MC - Multi-Company
+            Call Analyze_MC.Analyze_MC()
+            If OkToContinue = True Then
                 AnalysisStatusLbl.Text = "Finished analyzing Multi-Company"
             Else
                 AnalysisStatusLbl.Text = "Error encountered analyzing Multi-Company"
                 Exit Sub
             End If
 
-
+            'Analyze GL - General Ledger
+            Call Analyze_GL.Analyze_GL()
             If OkToContinue = True Then
-                'Analyze GL - General Ledger
-                Call Analyze_GL.Analyze_GL()
                 AnalysisStatusLbl.Text = "Finished analyzing General Ledger at " + Now.ToString("hh:mm:ss")
             Else
                 AnalysisStatusLbl.Text = "Error encountered analyzing the General Ledger Module"
                 Exit Sub
             End If
 
+            'Analyze AP - Accounts Payable
+            Call Analyze_AP.Analyze_AP()
             If OkToContinue = True Then
-                'Analyze AP - Accounts Payable
-                Call Analyze_AP.Analyze_AP()
                 AnalysisStatusLbl.Text = "Finished analyzing Accounts Payable at " + Now.ToString("hh:mm:ss")
             Else
                 AnalysisStatusLbl.Text = "Error encountered analyzing the Accounts Payable Module"
                 Exit Sub
             End If
 
+            'Analyze AR - Accounts Receivable
+            Call Analyze_AR.Analyze_AR()
             If OkToContinue = True Then
-                'Analyze AR - Accounts Receivable
-                Call Analyze_AR.Analyze_AR()
                 AnalysisStatusLbl.Text = "Finished analyzing Accounts Receivable at " + Now.ToString("hh:mm:ss")
             Else
                 AnalysisStatusLbl.Text = "Error encountered analyzing the Accounts Receivable Module"
+                Exit Sub
             End If
 
+            'Analyze CA - Cash Manager
+            Call Analyze_CA.Analyze_CA()
             If OkToContinue = True Then
-                'Analyze CA - Cash Manager
-                Call Analyze_CA.Analyze_CA()
                 AnalysisStatusLbl.Text = "Finished analyzing Cash Manager at " + Now.ToString("hh:mm:ss")
             Else
                 AnalysisStatusLbl.Text = "Error encountered analyzing the Cash Manager Module"
                 Exit Sub
             End If
 
+            'Analyze IN - Inventory
+            Call Analyze_IN.Analyze_IN()
             If OkToContinue = True Then
-                'Analyze IN - Inventory
-                Call Analyze_IN.Analyze_IN()
                 AnalysisStatusLbl.Text = "Finished analyzing Inventory at " + Now.ToString("hh:mm:ss")
             Else
                 AnalysisStatusLbl.Text = "Error encountered analyzing the Inventory Module"
                 Exit Sub
             End If
 
+            'Analyze BM - Bill of Material
+            Call Analyze_BM.Analyze_BM()
             If OkToContinue = True Then
-                'Analyze BM - Bill of Material
-                Call Analyze_BM.Analyze_BM()
                 AnalysisStatusLbl.Text = "Finished analyzing Bill of Material at " + Now.ToString("hh:mm:ss")
             Else
                 AnalysisStatusLbl.Text = "Error encountered analyzing the Bill of Material Module"
                 Exit Sub
             End If
 
+            'Analyze PO - Purchasing
+            Call Analyze_PO.Analyze_PO()
             If OkToContinue = True Then
-                'Analyze PO - Purchasing
-                Call Analyze_PO.Analyze_PO()
                 AnalysisStatusLbl.Text = "Finished analyzing Purchasing at " + Now.ToString("hh:mm:ss")
             Else
                 AnalysisStatusLbl.Text = "Error encountered analyzing the Purchasing Module"
                 Exit Sub
             End If
 
+            'Analyze RQ - Requisitions
+            Call Analyze_RQ.Analyze_RQ()
             If OkToContinue = True Then
-                'Analyze RQ - Requisitions
-                Call Analyze_RQ.Analyze_RQ()
                 AnalysisStatusLbl.Text = "Finished analyzing Requisitions at " + Now.ToString("hh:mm:ss")
             Else
                 AnalysisStatusLbl.Text = "Error encountered analyzing the Requisitions Module"
                 Exit Sub
             End If
 
+            'Analyze OM - Order Management
+            Call Analyze_OM.Analyze_OM()
             If OkToContinue = True Then
-                'Analyze OM - Order Management
-                Call Analyze_OM.Analyze_OM()
                 AnalysisStatusLbl.Text = "Finished analyzing Order Management at " + Now.ToString("hh:mm:ss")
             Else
                 AnalysisStatusLbl.Text = "Error encountered analyzing the Order Management Module"
                 Exit Sub
             End If
 
+            'Analyze PA - Project Controller
+            Call Analyze_PA.Analyze_PA()
             If OkToContinue = True Then
-                'Analyze PA - Project Controller
-                Call Analyze_PA.Analyze_PA()
                 AnalysisStatusLbl.Text = "Finished analyzing Project Controller at " + Now.ToString("hh:mm:ss")
             Else
                 AnalysisStatusLbl.Text = "Error encountered analyzing the Project Controller Module"
                 Exit Sub
             End If
 
+            'Analyze BI - Flexible Billings
+            Call Analyze_BI.Analyze_BI()
             If OkToContinue = True Then
-                'Analyze BI - Flexible Billings
-                Call Analyze_BI.Analyze_BI()
                 AnalysisStatusLbl.Text = "Finished analyzing Flexible Billings at " + Now.ToString("hh:mm:ss")
             Else
                 AnalysisStatusLbl.Text = "Error encountered analyzing the Flexible Billings Module"
                 Exit Sub
             End If
 
+            'Analyze TM - Time and Expense for Projects
+            Call Analyze_TM.Analyze_TM()
             If OkToContinue = True Then
-                'Analyze TM - Time and Expense for Projects
-                Call Analyze_TM.Analyze_TM()
                 AnalysisStatusLbl.Text = "Finished analyzing Time and Expense for Projects at " + Now.ToString("hh:mm:ss")
             Else
                 AnalysisStatusLbl.Text = "Error encountered analyzing the Time and Expense for Projects Module"
                 Exit Sub
             End If
 
+            'Analyze SD - Service Dispatch
+            Call Analyze_SD.Analyze_SD()
             If OkToContinue = True Then
-                'Analyze SD - Service Dispatch
-                Call Analyze_SD.Analyze_SD()
                 AnalysisStatusLbl.Text = "Finished analyzing Service Dispatch at " + Now.ToString("hh:mm:ss")
             Else
                 AnalysisStatusLbl.Text = "Error encountered analyzing the Service Dispatch Module"
                 Exit Sub
             End If
 
+            'Analyze SN - Service Contracts
+            Call Analyze_SN.Analyze_SN()
             If OkToContinue = True Then
-                'Analyze SN - Service Contracts
-                Call Analyze_SN.Analyze_SN()
                 AnalysisStatusLbl.Text = "Finished analyzing Service Contracts at " + Now.ToString("hh:mm:ss")
             Else
                 AnalysisStatusLbl.Text = "Error encountered analyzing the Service Contracts Module"
                 Exit Sub
             End If
 
+            'Analyze SI - Shared Information
+            Call Analyze_SI.Analyze_SI()
             If OkToContinue = True Then
-                'Analyze SI - Shared Information
-                Call Analyze_SI.Analyze_SI()
                 AnalysisStatusLbl.Text = "Finished analyzing Shared Information at " + Now.ToString("hh:mm:ss")
             Else
-                ' AnalysisStatusLbl.Text = "Error encountered analyzing the Time and Expense for Projects Module", LOG_AND_DISP)
                 AnalysisStatusLbl.Text = "Error encountered analyzing the Shared Information Module"
                 Exit Sub
             End If
 
+            'Analyze CM - Currency Manager
+            Call Analyze_CM.Analyze_CM()
             If OkToContinue = True Then
-                'Analyze CM - Currency Manager
-                Call Analyze_CM.Analyze_CM()
                 AnalysisStatusLbl.Text = "Finished analyzing Currency Manager at " + Now.ToString("hh:mm:ss")
             Else
-                AnalysisStatusLbl.Text = "Error encountered analyzing the  Currency Manager Module"
+                AnalysisStatusLbl.Text = "Error encountered analyzing the Currency Manager Module"
                 Exit Sub
             End If
 


### PR DESCRIPTION
Correct errors when a SL module is not used (No setup record or transactions. Added the Stack Trace to exception messages displayed.