### PR TITLE
GP Diagnostic Tool: Increase character limit check for Customer and Vendors names

### DIFF
--- a/samples/DynamicsGPDiagnosticTool/GP_Diagnostic/Analysis/Tasks/GpCustomerNameLengthTask.cs
+++ b/samples/DynamicsGPDiagnosticTool/GP_Diagnostic/Analysis/Tasks/GpCustomerNameLengthTask.cs
@@ -50,7 +50,7 @@ public class GpCustomerNameLengthTask : IDiagnosticTask
 FROM
     [RM00101]
 WHERE
-    LEN([CUSTNAME]) > 50";
+    LEN([CUSTNAME]) > 100";
 
         using (var reader = await this.database.ExecuteSqlAsync(sql, cancellationToken))
         {

--- a/samples/DynamicsGPDiagnosticTool/GP_Diagnostic/Analysis/Tasks/GpVendorNameLengthTask.cs
+++ b/samples/DynamicsGPDiagnosticTool/GP_Diagnostic/Analysis/Tasks/GpVendorNameLengthTask.cs
@@ -50,7 +50,7 @@ public class GpVendorNameLengthTask : IDiagnosticTask
 FROM
     [PM00200]
 WHERE
-    LEN([VENDNAME]) > 50";
+    LEN([VENDNAME]) > 100";
 
         using (var reader = await this.database.ExecuteSqlAsync(sql, cancellationToken))
         {

--- a/samples/DynamicsGPDiagnosticTool/GP_Diagnostic/Resources.Designer.cs
+++ b/samples/DynamicsGPDiagnosticTool/GP_Diagnostic/Resources.Designer.cs
@@ -226,7 +226,7 @@ namespace Microsoft.GP.MigrationDiagnostic {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} customer name(s) over 50 characters. Business Central requires Customer names to be 50 or fewer characters. Customer names greater than 50 characters will be truncated when migrated. This may cause duplicate Customers in Business Central and other integrating services depending on Customer names may no longer work..
+        ///   Looks up a localized string similar to {0} customer name(s) over 100 characters. Business Central requires Customer names to be 100 or fewer characters. Customer names greater than 100 characters will be truncated when migrated. This may cause duplicate Customers in Business Central and other integrating services depending on Customer names may no longer work..
         /// </summary>
         internal static string GpCustomerNameLengthTaskSummary {
             get {
@@ -685,7 +685,7 @@ namespace Microsoft.GP.MigrationDiagnostic {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} vendor name(s) over 50 characters. Business Central requires Vendor names to be 50 or fewer characters. Vendor names greater than 50 characters will be truncated when migrated. This may cause duplicate Vendors in Business Central and other integrating services depending on Vendor names may no longer work..
+        ///   Looks up a localized string similar to {0} vendor name(s) over 100 characters. Business Central requires Vendor names to be 100 or fewer characters. Vendor names greater than 100 characters will be truncated when migrated. This may cause duplicate Vendors in Business Central and other integrating services depending on Vendor names may no longer work..
         /// </summary>
         internal static string GpVendorNameLengthTaskSummary {
             get {

--- a/samples/DynamicsGPDiagnosticTool/GP_Diagnostic/Resources.resx
+++ b/samples/DynamicsGPDiagnosticTool/GP_Diagnostic/Resources.resx
@@ -180,7 +180,7 @@
     <value>Customer name length</value>
   </data>
   <data name="GpCustomerNameLengthTaskSummary" xml:space="preserve">
-    <value>{0} customer name(s) over 50 characters. Business Central requires Customer names to be 50 or fewer characters. Customer names greater than 50 characters will be truncated when migrated. This may cause duplicate Customers in Business Central and other integrating services depending on Customer names may no longer work.</value>
+    <value>{0} customer name(s) over 100 characters. Business Central requires Customer names to be 100 or fewer characters. Customer names greater than 100 characters will be truncated when migrated. This may cause duplicate Customers in Business Central and other integrating services depending on Customer names may no longer work.</value>
     <comment>{0} = Number of customers</comment>
   </data>
   <data name="GpCustomerPhoneNumberAlphaTaskDescription" xml:space="preserve">
@@ -359,7 +359,7 @@
     <value>Vendor name length</value>
   </data>
   <data name="GpVendorNameLengthTaskSummary" xml:space="preserve">
-    <value>{0} vendor name(s) over 50 characters. Business Central requires Vendor names to be 50 or fewer characters. Vendor names greater than 50 characters will be truncated when migrated. This may cause duplicate Vendors in Business Central and other integrating services depending on Vendor names may no longer work.</value>
+    <value>{0} vendor name(s) over 100 characters. Business Central requires Vendor names to be 100 or fewer characters. Vendor names greater than 100 characters will be truncated when migrated. This may cause duplicate Vendors in Business Central and other integrating services depending on Vendor names may no longer work.</value>
     <comment>{0} = Number of vendors</comment>
   </data>
   <data name="GpVendorPhoneNumberAlphaTaskDescription" xml:space="preserve">


### PR DESCRIPTION
The Customer and Vendor name field in BC was increased from 50 to 100 characters. The GP migration tool has been updated to support this change, and this PR is for updating the GP Diagnostic Tool to also support that change.