### PR TITLE
Fix BC MCP proxy to target current MCP server endpoint

### DIFF
--- a/samples/BcMCPProxy/Models/ConfigOptions.cs
+++ b/samples/BcMCPProxy/Models/ConfigOptions.cs
@@ -16,9 +16,9 @@
 
         public string ClientId { get; set; } = "3acde393-18cc-4b12-803c-4c85fa111c21";
 
-        public string TokenScope { get; set; } = "https://api.businesscentral.dynamics.com/.default";
+        public string TokenScope { get; set; } = "https://mcp.businesscentral.dynamics.com/.default";
 
-        public string Url { get; set; } = "https://api.businesscentral.dynamics.com";
+        public string Url { get; set; } = "https://mcp.businesscentral.dynamics.com";
 
         public string Environment { get; set; } = "Production";
 

--- a/samples/BcMCPProxy/Runtime/MCPServerProxy.cs
+++ b/samples/BcMCPProxy/Runtime/MCPServerProxy.cs
@@ -43,11 +43,13 @@ public class MCPServerProxy
         var transportOptions = new HttpClientTransportOptions
         {
             Name = "Test Server",
-            Endpoint = new Uri(this.configOptions.Url.TrimEnd('/') + "/v2.0/" + this.configOptions.Environment + "/mcp"),
+            Endpoint = new Uri(this.configOptions.Url.TrimEnd('/')),
             TransportMode = HttpTransportMode.StreamableHttp,
             AdditionalHeaders = new Dictionary<string, string>
             {
-                { "Company",  HttpUtility.UrlDecode(this.configOptions.Company) },
+                { "TenantId", this.configOptions.TenantId },
+                { "EnvironmentName", this.configOptions.Environment },
+                { "Company", HttpUtility.UrlDecode(this.configOptions.Company) },
                 { "X-Client-Application", "BcMCPProxy" }
             }
         };

--- a/samples/BcMCPProxyPython/README.md
+++ b/samples/BcMCPProxyPython/README.md
@@ -94,8 +94,8 @@ Example interactions:
 | Company | `--Company` | `BC_COMPANY` | Business Central company name | Yes |
 | Configuration Name | `--ConfigurationName` | `BC_CONFIGURATION_NAME` | Name of the Business Central configuration | No |
 | Custom Auth Header | `--CustomAuthHeader` | `BC_CUSTOM_AUTH_HEADER` | Pre-issued bearer token (skips device flow) | No |
-| Base URL | `--BaseUrl` | `BC_BASE_URL` | Base API URL (default: `https://api.businesscentral.dynamics.com`) | No |
-| Token Scope | `--TokenScope` | `BC_TOKEN_SCOPE` | OAuth scope (default: `https://api.businesscentral.dynamics.com/.default`) | No |
+| Base URL | `--BaseUrl` | `BC_BASE_URL` | MCP server URL (default: `https://mcp.businesscentral.dynamics.com`) | No |
+| Token Scope | `--TokenScope` | `BC_TOKEN_SCOPE` | OAuth scope (default: `https://mcp.businesscentral.dynamics.com/.default`) | No |
 | Log Level | `--LogLevel` | `BC_LOG_LEVEL` | Logging level (default: `INFO`) | No |
 | Debug | `--Debug` | `BC_DEBUG=1` | Enable verbose logging | No |
 

--- a/samples/BcMCPProxyPython/bc_mcp_proxy/config.py
+++ b/samples/BcMCPProxyPython/bc_mcp_proxy/config.py
@@ -14,8 +14,8 @@ class ProxyConfig:
 
   tenant_id: Optional[str] = None
   client_id: Optional[str] = None
-  token_scope: str = "https://api.businesscentral.dynamics.com/.default"
-  base_url: str = "https://api.businesscentral.dynamics.com"
+  token_scope: str = "https://mcp.businesscentral.dynamics.com/.default"
+  base_url: str = "https://mcp.businesscentral.dynamics.com"
   environment: str = "Production"
   company: Optional[str] = None
   configuration_name: Optional[str] = None

--- a/samples/BcMCPProxyPython/bc_mcp_proxy/proxy.py
+++ b/samples/BcMCPProxyPython/bc_mcp_proxy/proxy.py
@@ -91,6 +91,10 @@ def _build_transport_headers(config: ProxyConfig) -> dict[str, str]:
   headers: dict[str, str] = {
       "X-Client-Application": config.server_name,
   }
+  if config.tenant_id:
+    headers["TenantId"] = config.tenant_id
+  if config.environment:
+    headers["EnvironmentName"] = config.environment
   if config.company:
     headers["Company"] = unquote(config.company)
   if config.configuration_name:
@@ -99,8 +103,7 @@ def _build_transport_headers(config: ProxyConfig) -> dict[str, str]:
 
 
 def _build_endpoint_url(config: ProxyConfig) -> str:
-  base = config.base_url.rstrip("/")
-  return f"{base}/v2.0/{config.environment}/mcp"
+  return config.base_url.rstrip("/")
 
 
 def run_sync(config: ProxyConfig) -> None:

--- a/samples/BcMCPProxyPython/pyproject.toml
+++ b/samples/BcMCPProxyPython/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bc-mcp-proxy"
-version = "0.1.2"
+version = "0.1.4"
 description = "Python-based MCP stdio proxy for Microsoft Dynamics 365 Business Central"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

The Business Central MCP proxy samples (Python `bc-mcp-proxy` and .NET `BcMCPProxy`) currently fail with **HTTP 400 Bad Request** as soon as they try to talk to Business Central, even when device-code sign-in succeeds and the Azure app registration is configured exactly as documented.

Root cause: Microsoft moved the BC MCP server. The proxies still call the **old** preview URL pattern, which BC no longer accepts.

| | Old (broken) | Current (fixed) |
|---|---|---|
| URL | `https://api.businesscentral.dynamics.com/v2.0/<env>/mcp` | `https://mcp.businesscentral.dynamics.com` |
| Routing | environment in path, `Company` header only | `TenantId`, `EnvironmentName`, `Company` HTTP headers |
| OAuth scope | `https://api.businesscentral.dynamics.com/.default` | `https://mcp.businesscentral.dynamics.com/.default` |

This matches the official guidance in [Connect to Business Central MCP server with non-Microsoft clients](https://learn.microsoft.com/dynamics365/business-central/dev-itpro/ai/use-mcp-server-non-microsoft) and the connection string emitted by the **Model Context Protocol (MCP) Server Configurations** page in BC.

## Changes

- `samples/BcMCPProxyPython/bc_mcp_proxy/config.py` — update `base_url` and `token_scope` defaults
- `samples/BcMCPProxyPython/bc_mcp_proxy/proxy.py` — drop `/v2.0/<env>/mcp` path suffix, add `TenantId` / `EnvironmentName` headers
- `samples/BcMCPProxyPython/README.md` — update parameter table defaults to match
- `samples/BcMCPProxy/Models/ConfigOptions.cs` — update `Url` and `TokenScope` defaults
- `samples/BcMCPProxy/Runtime/MCPServerProxy.cs` — same URL/header changes for the .NET proxy

## Test plan

Verified end-to-end against a sandbox BC environment:

- [x] Device-code sign-in succeeds and acquires a token for the `mcp.businesscentral.dynamics.com` resource
- [x] MCP `initialize` handshake completes against `mcp.businesscentral.dynamics.com` (HTTP 200, server identifies itself as `Microsoft Dynamics 365 Business Central` v28.0)
- [x] `tools/list` returns the BC dynamic tools (`bc_actions_search`, `bc_actions_describe`, `bc_actions_invoke`)
- [x] `bc_actions_search` returns matching action names
- [x] `bc_actions_describe` returns the action schema
- [x] `bc_actions_invoke` on `List_Customers_PAG30009` returns real CRONUS customer data (3 of 5 records)
- [x] `bc_actions_invoke` on `List_Items_PAG30008` returns real CRONUS item data (3 of 80 records)

Existing app registrations that already have `Dynamics 365 Business Central` → `user_impersonation` (delegated) continue to work — no Azure changes are required for end users.

## Reproduction

Before this PR (with valid app registration and successful device-code sign-in):
```
INFO:bc_mcp_proxy:Connecting to Business Central MCP endpoint at https://api.businesscentral.dynamics.com/v2.0/Production/mcp
INFO:httpx:HTTP Request: POST https://api.businesscentral.dynamics.com/v2.0/Production/mcp "HTTP/1.1 400 Bad Request"
```

After this PR:
```
INFO:bc_mcp_proxy:Connecting to Business Central MCP endpoint at https://mcp.businesscentral.dynamics.com
INFO:httpx:HTTP Request: POST https://mcp.businesscentral.dynamics.com "HTTP/1.1 200 OK"
DEBUG:bc_mcp_proxy:Connected to remote MCP server (protocol 2025-11-25)
```

## Notes for maintainers

- The Python sample's `pyproject.toml` version is unchanged (`0.1.2`). Once this PR is merged, the package will need a version bump and a PyPI release so end users get the fix without rebuilding from source.
- The `BcMCPProxy.exe` published artifact will likewise need a rebuild.
